### PR TITLE
Prophet/6 new algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.1.0
+### Added Algorithms
+Added support for Hashing Algorithms SHA384 and RIPEMD160.  You can now specify them using the HashTypes enum.
+
+
 # v1.0.1
 ### Unit Tests Created
 Simply added unit tests to the project and removed a few small references

--- a/ProphetsWay.Hasher.Tests/HasherTests.cs
+++ b/ProphetsWay.Hasher.Tests/HasherTests.cs
@@ -11,15 +11,28 @@ namespace ProphetsWay.Hasher.Tests
 		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.MD5, HashTypes.MD5)]
 		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA1, HashTypes.SHA1)]
 		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA256, HashTypes.SHA256)]
+		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA384, HashTypes.SHA384)]
 		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.MD5, HashTypes.MD5)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA1, HashTypes.SHA1)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA256, HashTypes.SHA256)]
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA384, HashTypes.SHA384)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA512, HashTypes.SHA512)]
 		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.MD5, HashTypes.MD5)]
 		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA1, HashTypes.SHA1)]
 		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA256, HashTypes.SHA256)]
+		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA384, HashTypes.SHA384)]
 		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA512, HashTypes.SHA512)]
+#if NET451 || NET452 || NET46 || NET461 || NET471 || NET472 || NET48
+		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.RIPEMD160, HashTypes.RIPEMD160)]
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.RIPEMD160, HashTypes.RIPEMD160)]
+		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.RIPEMD160, HashTypes.RIPEMD160)]
+#endif
+		/// <summary>
+		/// This is meant to test all possible combinations of HashTypes,
+		/// all other functionality relies on calling this, and thus won't need
+		/// to be explicitly tested
+		/// </summary>
 		public void TestGenerateHashFromStream(string filename, string expectedHash, HashTypes hashType)
 		{
 			var fi = new FileInfo(filename);
@@ -30,20 +43,15 @@ namespace ProphetsWay.Hasher.Tests
 			hashResult.Should().Be(expectedHash);
 		}
 
-		[Theory]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.MD5, HashTypes.MD5, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA1, HashTypes.SHA1, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA256, HashTypes.SHA256, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512, true)]
+		[Theory]		
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.MD5, HashTypes.MD5, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA1, HashTypes.SHA1, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA256, HashTypes.SHA256, true)]
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA384, HashTypes.SHA384, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA512, HashTypes.SHA512, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.MD5, HashTypes.MD5, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA1, HashTypes.SHA1, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA256, HashTypes.SHA256, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA512, HashTypes.SHA512, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512, false)]
+#if NET451 || NET452 || NET46 || NET461 || NET471 || NET472 || NET48
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.RIPEMD160, HashTypes.RIPEMD160, true)]
+#endif
 		public void TestVerifyHashFromStream(string filename, string expectedHash, HashTypes hashType, bool expectedOutcome)
 		{
 			var fi = new FileInfo(filename);
@@ -55,18 +63,14 @@ namespace ProphetsWay.Hasher.Tests
 		}
 
 		[Theory]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.MD5, HashTypes.MD5, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA1, HashTypes.SHA1, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA256, HashTypes.SHA256, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.MD5, HashTypes.MD5, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA1, HashTypes.SHA1, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA256, HashTypes.SHA256, true)]
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA384, HashTypes.SHA384, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA512, HashTypes.SHA512, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.MD5, HashTypes.MD5, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA1, HashTypes.SHA1, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA256, HashTypes.SHA256, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA512, HashTypes.SHA512, true)]
+#if NET451 || NET452 || NET46 || NET461 || NET471 || NET472 || NET48
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.RIPEMD160, HashTypes.RIPEMD160, true)]
+#endif
 		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512, false)]
 		public void TestVerifyWithUpperCaseHashFromStream(string filename, string expectedHash, HashTypes hashType, bool expectedOutcome)
 		{
@@ -79,18 +83,14 @@ namespace ProphetsWay.Hasher.Tests
 		}
 
 		[Theory]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.MD5, HashTypes.MD5)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA1, HashTypes.SHA1)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA256, HashTypes.SHA256)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.MD5, HashTypes.MD5)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA1, HashTypes.SHA1)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA256, HashTypes.SHA256)]
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA384, HashTypes.SHA384)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA512, HashTypes.SHA512)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.MD5, HashTypes.MD5)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA1, HashTypes.SHA1)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA256, HashTypes.SHA256)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA512, HashTypes.SHA512)]
+#if NET451 || NET452 || NET46 || NET461 || NET471 || NET472 || NET48
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.RIPEMD160, HashTypes.RIPEMD160)]
+#endif
 		public void TestGenerateHashFromFileInfo(string filename, string expectedHash, HashTypes hashType)
 		{
 			var fi = new FileInfo(filename);
@@ -101,18 +101,14 @@ namespace ProphetsWay.Hasher.Tests
 		}
 
 		[Theory]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.MD5, HashTypes.MD5, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA1, HashTypes.SHA1, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA256, HashTypes.SHA256, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.MD5, HashTypes.MD5, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA1, HashTypes.SHA1, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA256, HashTypes.SHA256, true)]
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA384, HashTypes.SHA384, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA512, HashTypes.SHA512, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.MD5, HashTypes.MD5, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA1, HashTypes.SHA1, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA256, HashTypes.SHA256, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA512, HashTypes.SHA512, true)]
+#if NET451 || NET452 || NET46 || NET461 || NET471 || NET472 || NET48
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.RIPEMD160, HashTypes.RIPEMD160, true)]
+#endif
 		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512, false)]
 		public void TestVerifyHashFromFileInfo(string filename, string expectedHash, HashTypes hashType, bool expectedOutcome)
 		{
@@ -124,18 +120,14 @@ namespace ProphetsWay.Hasher.Tests
 		}
 
 		[Theory]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.MD5, HashTypes.MD5, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA1, HashTypes.SHA1, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA256, HashTypes.SHA256, true)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.MD5, HashTypes.MD5, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA1, HashTypes.SHA1, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA256, HashTypes.SHA256, true)]
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA384, HashTypes.SHA384, true)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA512, HashTypes.SHA512, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.MD5, HashTypes.MD5, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA1, HashTypes.SHA1, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA256, HashTypes.SHA256, true)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA512, HashTypes.SHA512, true)]
+#if NET451 || NET452 || NET46 || NET461 || NET471 || NET472 || NET48
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.RIPEMD160, HashTypes.RIPEMD160, true)]
+#endif
 		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512, false)]
 		public void TestVerifyWithUpperCaseHashFromFileInfo(string filename, string expectedHash, HashTypes hashType, bool expectedOutcome)
 		{
@@ -147,18 +139,14 @@ namespace ProphetsWay.Hasher.Tests
 		}
 
 		[Theory]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.MD5, HashTypes.MD5)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA1, HashTypes.SHA1)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA256, HashTypes.SHA256)]
-		[InlineData(TestFiles.TestFileA.Name, TestFiles.TestFileA.SHA512, HashTypes.SHA512)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.MD5, HashTypes.MD5)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA1, HashTypes.SHA1)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA256, HashTypes.SHA256)]
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA384, HashTypes.SHA384)]
 		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.SHA512, HashTypes.SHA512)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.MD5, HashTypes.MD5)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA1, HashTypes.SHA1)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA256, HashTypes.SHA256)]
-		[InlineData(TestFiles.TestFileC.Name, TestFiles.TestFileC.SHA512, HashTypes.SHA512)]
+#if NET451 || NET452 || NET46 || NET461 || NET471 || NET472 || NET48
+		[InlineData(TestFiles.TestFileB.Name, TestFiles.TestFileB.RIPEMD160, HashTypes.RIPEMD160)]
+#endif
 		public void TestGenerateHashFromFileName(string filename, string expectedHash, HashTypes hashType)
 		{
 			var hashResult = Utilities.Hasher.GenerateHash(filename, hashType);

--- a/ProphetsWay.Hasher.Tests/TestFiles.cs
+++ b/ProphetsWay.Hasher.Tests/TestFiles.cs
@@ -6,8 +6,10 @@
 		{
 			public const string Name = "TestFileA.txt";
 			public const string MD5 = "94368a509401d8e56ea5e8c1592262ff";
+			public const string RIPEMD160 = "82b075d61a3827cfaae5bc85a67779c70de0c9ca";
 			public const string SHA1 = "5943684f0a4af2f0e318ef5ea1803d26b521214a";
 			public const string SHA256 = "4b20b968d857a92ddc033d1b374cc944b978db96cb7d9056e60bc9f31f3fba14";
+			public const string SHA384 = "0ba577302ae5aa9d2e4679fb63fe5106f4a0aba6209f31e5d695f526a9a04c61361d3af42300e39f7c61833d1565104b";
 			public const string SHA512 = "bd0f33984375e47737098050bfea5468b76675942e1bd22ce6744590ed4bfe6780e02a632fa98f310a004931d19f2627fd7ddc62c0609ca320409110ed273874";
 		}
 
@@ -15,8 +17,10 @@
 		{
 			public const string Name = "TestFileB.bmp";
 			public const string MD5 = "7f5f5b7b76e6cef0e1271c421a9d2e1a";
+			public const string RIPEMD160 = "f2a295927aa281b553e213ad3c565d57e7d33654";
 			public const string SHA1 = "253eecc784d7249fb3b61448f80054bd886c16e0";
 			public const string SHA256 = "03378b1990ca7197d925ba6c9f77a1636fa4b590b7a32f1278f6449d17bceb35";
+			public const string SHA384 = "f68f335948faf3c9acbf8bf7b9df2d62d1e329372caee145f4af457859f302ecdbac750b95a87c1346497d183d7c83f4";
 			public const string SHA512 = "f0e5f8c33f3dd29e94d83141cd7912b30377cd76f5fbbf516a03382be0daf6b6dc2d851ef73b0039e7178bbb1d9f3f926ec16bd0171ce57a69f6d17665ab6b0e";
 		}
 
@@ -24,8 +28,10 @@
 		{
 			public const string Name = "TestFileC.bin";
 			public const string MD5 = "f4d61fcb46717d50e9bac2dbaf274cc9";
+			public const string RIPEMD160 = "9905e35e327f8c8939ff11db43abbd453f8af89d";
 			public const string SHA1 = "60982813bf73f2acf8b4d8603021547299d7b03d";
 			public const string SHA256 = "6b908d70ee1ac865a96f8fbee3c7b9f960d357cd5c02a43dac082f498c99514b";
+			public const string SHA384 = "adef62f3cfa6e3e37bc47fb079c747bfc3a77ca5824c51d9a13d1c8ad5de191a72d25cd456d132db6db5a6d42b794f1e";
 			public const string SHA512 = "cf60b1c0dad7207bce20e14e3177e57561732eb702892c30a7fec4fbb4ba76cfffd78fd636971aa4f299b81d15ac8ccb3f320506eaefb96b96f462dd09994f72";
 		}
 	}

--- a/ProphetsWay.Hasher/HashFactory.cs
+++ b/ProphetsWay.Hasher/HashFactory.cs
@@ -1,0 +1,40 @@
+﻿using System.ComponentModel;
+using System.Security.Cryptography;
+
+namespace ProphetsWay.Utilities
+{
+	public static class HashFactory
+	{
+		public static HashAlgorithm GetHasher(this HashTypes hashType)
+		{
+			switch (hashType)
+			{
+				case HashTypes.MD5:
+					return new MD5CryptoServiceProvider();
+
+				case HashTypes.SHA1:
+					return new SHA1Managed();
+
+				case HashTypes.SHA256:
+					return new SHA256Managed();
+
+				case HashTypes.SHA384:
+					return new SHA384Managed();
+
+				case HashTypes.SHA512:
+					return new SHA512Managed();
+
+#if NET451 || NET452 || NET46 || NET461 || NET471 || NET472 || NET48
+				case HashTypes.RIPEMD160:
+					return new RIPEMD160Managed();
+#endif
+				default:
+					throw new InvalidEnumArgumentException("Improper/unknown value of HashType was used.");
+			}
+		}
+	}
+}
+
+
+
+

--- a/ProphetsWay.Hasher/HashTypes.cs
+++ b/ProphetsWay.Hasher/HashTypes.cs
@@ -1,10 +1,17 @@
 ﻿namespace ProphetsWay.Utilities
 {
-    public enum HashTypes
-    {
-        MD5,
-        SHA1,
-        SHA256,
-        SHA512,
-    }
+	public enum HashTypes
+	{
+		MD5,
+		SHA1,
+		SHA256,
+		SHA384,
+		SHA512,
+#if NET451 || NET452 || NET46 || NET461 || NET471 || NET472 || NET48
+		RIPEMD160		
+#endif
+	}
 }
+
+
+

--- a/ProphetsWay.Hasher/HashWorker.cs
+++ b/ProphetsWay.Hasher/HashWorker.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.IO;
 using System.Security.Cryptography;
 
@@ -16,28 +15,7 @@ namespace ProphetsWay.Utilities
         public HashWorker(HashTypes hashType)
         {
             _hashType = hashType;
-
-            switch (_hashType)
-            {
-                case HashTypes.MD5:
-                    Hasher = new MD5CryptoServiceProvider();
-                    break;
-
-                case HashTypes.SHA1:
-                    Hasher = new SHA1Managed();
-                    break;
-
-                case HashTypes.SHA256:
-                    Hasher = new SHA256Managed();
-                    break;
-
-                case HashTypes.SHA512:
-                    Hasher = new SHA512Managed();
-                    break;
-
-                default:
-                    throw new InvalidEnumArgumentException("Improper value of HashType was used.");
-            }
+            Hasher = hashType.GetHasher();
         }
 
         public void GenerateHash(Stream stream)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,8 @@ pr:
 
 variables:
   MajorVersion: '1'
-  MinorVersion: '0'
-  PatchVersion: '1'
+  MinorVersion: '1'
+  PatchVersion: '0'
 
 
 stages:


### PR DESCRIPTION
#6   Added support for two additional hashing algorithms supported in .net 

RIPEMD160 is only available in .NetFramework, it is not supported in .NetStandard or NetCore.